### PR TITLE
fix: cinder-manila filers discovery

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -4,6 +4,5 @@ LABEL source_repository="https://github.com/sapcc/netappsd"
 ENV GOGC=100
 RUN apk add --update curl yq && rm -rf /var/cache/apk/*
 
-WORKDIR /app
-COPY netappsd netappsd
-ENTRYPOINT [ "/app/netappsd" ]
+COPY netappsd /netappsd
+ENTRYPOINT [ "/netappsd" ]

--- a/internal/pkg/netbox/filer.go
+++ b/internal/pkg/netbox/filer.go
@@ -17,8 +17,28 @@ func (c Client) GetFilers(ctx context.Context, region, query string) (filers []F
 	switch query {
 	case "md", "manila":
 		filers, err = c.getNetAppFilers(ctx, region, "manila")
+		if err != nil {
+			return nil, err
+		}
+		// Exclude filers that have both cinder and manila tags
+		dualTagged, err := c.getFilers(ctx, region, "cinder", "manila")
+		if err != nil {
+			return nil, err
+		}
+		filers = excludeFilers(filers, dualTagged)
 	case "bb", "cinder":
 		filers, err = c.getNetAppFilers(ctx, region, "cinder")
+		if err != nil {
+			return nil, err
+		}
+		// Exclude filers that have both cinder and manila tags
+		dualTagged, err := c.getFilers(ctx, region, "cinder", "manila")
+		if err != nil {
+			return nil, err
+		}
+		filers = excludeFilers(filers, dualTagged)
+	case "cm", "cinder-manila", "cinder_manila":
+		filers, err = c.getFilers(ctx, region, "cinder", "manila")
 	case "bm", "baremetal":
 		filers, err = c.getNetAppFilers(ctx, region, "baremetal")
 	case "apod", "cp", "control-plane", "control_plane":
@@ -30,4 +50,19 @@ func (c Client) GetFilers(ctx context.Context, region, query string) (filers []F
 		return nil, err
 	}
 	return filers, nil
+}
+
+// excludeFilers removes filers from the list that are present in the exclude list.
+func excludeFilers(filers, exclude []Filer) []Filer {
+	excludeMap := make(map[string]struct{}, len(exclude))
+	for _, f := range exclude {
+		excludeMap[f.Name] = struct{}{}
+	}
+	result := make([]Filer, 0, len(filers))
+	for _, f := range filers {
+		if _, ok := excludeMap[f.Name]; !ok {
+			result = append(result, f)
+		}
+	}
+	return result
 }

--- a/internal/pkg/netbox/netbox_client.go
+++ b/internal/pkg/netbox/netbox_client.go
@@ -38,7 +38,7 @@ func (c Client) getNetAppFilers(ctx context.Context, region, tag string) ([]File
 // from the first node of the filer.
 //
 // EG https://netbox.global.cloud.sap/dcim/devices/?region_id=19&role_id=13&manufacturer_id=11&tenant_id=1&interfaces=False
-func (c Client) getFilers(ctx context.Context, region, tag string) ([]Filer, error) {
+func (c Client) getFilers(ctx context.Context, region string, tags ...string) ([]Filer, error) {
 	netappFilers := make([]Filer, 0)
 	devices := make([]netbox.DeviceWithConfigContext, 0)
 
@@ -50,7 +50,7 @@ func (c Client) getFilers(ctx context.Context, region, tag string) ([]Filer, err
 			Role([]string{"filer"}).
 			Manufacturer([]string{"netapp"}).
 			Region([]string{region}).
-			Tag([]string{tag}).
+			Tag(tags).
 			Interfaces(false).
 			Limit(limit).
 			Offset(offset).


### PR DESCRIPTION
Added `cinder-manila` discovery for the filers that has both the `cinder` and `manila` labels.

Test Results:

This change will create a new master - <helm-release-name>-cinder-manila-master
```bash
k get deploy | grep master

harvest-qade1-apod-master            1/1     1            1           15h
harvest-qade1-cinder-manila-master   1/1     1            1           15h
harvest-qade1-cinder-master          1/1     1            1           15h
harvest-qade1-manila-master          1/1     1            1           15h
```

```bash
k logs harvest-qade1-cinder-manila-master-5cf8dcccb-tv7dj | head -n 20       
                                                                                                                             
time=2026-06-03T00:04:18.352Z level=DEBUG msg="probing filer" filer=stnpca2-st051 addr=10.246.250.32
time=2026-06-03T00:04:18.352Z level=DEBUG msg="probing filer" filer=stnpca1-st035 addr=10.247.26.9
time=2026-06-03T00:04:18.352Z level=DEBUG msg="probing filer" filer=stnpca1-st036 addr=10.246.250.4
time=2026-06-03T00:04:18.352Z level=DEBUG msg="probing filer" filer=stnpca1-bb097 addr=10.246.246.6
time=2026-06-03T00:04:18.352Z level=DEBUG msg="probing filer" filer=stnpca2-md004 addr=10.246.246.24
time=2026-06-03T00:04:18.415Z level=INFO msg="filer discovery done" success=5 failed=0
time=2026-06-03T00:09:21.744Z level=DEBUG msg="probing filer" filer=stnpca2-st051 addr=10.246.250.32
time=2026-06-03T00:09:21.744Z level=DEBUG msg="probing filer" filer=stnpca1-bb097 addr=10.246.246.6
time=2026-06-03T00:09:21.744Z level=DEBUG msg="probing filer" filer=stnpca1-st036 addr=10.246.250.4
time=2026-06-03T00:09:21.744Z level=DEBUG msg="probing filer" filer=stnpca2-md004 addr=10.246.246.24
time=2026-06-03T00:09:21.744Z level=DEBUG msg="probing filer" filer=stnpca1-st035 addr=10.247.26.9
time=2026-06-03T00:09:21.811Z level=INFO msg="filer discovery done" success=5 failed=0
time=2026-06-03T00:14:23.988Z level=DEBUG msg="probing filer" filer=stnpca2-st051 addr=10.246.250.32
time=2026-06-03T00:14:23.988Z level=DEBUG msg="probing filer" filer=stnpca1-st035 addr=10.247.26.9
time=2026-06-03T00:14:23.988Z level=DEBUG msg="probing filer" filer=stnpca1-st036 addr=10.246.250.4
time=2026-06-03T00:14:23.988Z level=DEBUG msg="probing filer" filer=stnpca2-md004 addr=10.246.246.24
time=2026-06-03T00:14:23.989Z level=DEBUG msg="probing filer" filer=stnpca1-bb097 addr=10.246.246.6
```

