### PR TITLE
fix: cinder-manila filers discovery

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -4,6 +4,5 @@ LABEL source_repository="https://github.com/sapcc/netappsd"
 ENV GOGC=100
 RUN apk add --update curl yq && rm -rf /var/cache/apk/*
 
-WORKDIR /app
-COPY netappsd netappsd
-ENTRYPOINT [ "/app/netappsd" ]
+COPY netappsd /netappsd
+ENTRYPOINT [ "/netappsd" ]

--- a/internal/pkg/netbox/filer.go
+++ b/internal/pkg/netbox/filer.go
@@ -17,8 +17,28 @@ func (c Client) GetFilers(ctx context.Context, region, query string) (filers []F
 	switch query {
 	case "md", "manila":
 		filers, err = c.getNetAppFilers(ctx, region, "manila")
+		if err != nil {
+			return nil, err
+		}
+		// Exclude filers that have both cinder and manila tags
+		dualTagged, err := c.getFilers(ctx, region, "cinder", "manila")
+		if err != nil {
+			return nil, err
+		}
+		filers = excludeFilers(filers, dualTagged)
 	case "bb", "cinder":
 		filers, err = c.getNetAppFilers(ctx, region, "cinder")
+		if err != nil {
+			return nil, err
+		}
+		// Exclude filers that have both cinder and manila tags
+		dualTagged, err := c.getFilers(ctx, region, "cinder", "manila")
+		if err != nil {
+			return nil, err
+		}
+		filers = excludeFilers(filers, dualTagged)
+	case "cm", "cinder-manila", "cinder_manila":
+		filers, err = c.getFilers(ctx, region, "cinder", "manila")
 	case "bm", "baremetal":
 		filers, err = c.getNetAppFilers(ctx, region, "baremetal")
 	case "apod", "cp", "control-plane", "control_plane":
@@ -30,4 +50,19 @@ func (c Client) GetFilers(ctx context.Context, region, query string) (filers []F
 		return nil, err
 	}
 	return filers, nil
+}
+
+// excludeFilers removes filers from the list that are present in the exclude list.
+func excludeFilers(filers, exclude []Filer) []Filer {
+	excludeMap := make(map[string]struct{}, len(exclude))
+	for _, f := range exclude {
+		excludeMap[f.Name] = struct{}{}
+	}
+	result := make([]Filer, 0, len(filers))
+	for _, f := range filers {
+		if _, ok := excludeMap[f.Name]; !ok {
+			result = append(result, f)
+		}
+	}
+	return result
 }

--- a/internal/pkg/netbox/netbox_client.go
+++ b/internal/pkg/netbox/netbox_client.go
@@ -38,7 +38,7 @@ func (c Client) getNetAppFilers(ctx context.Context, region, tag string) ([]File
 // from the first node of the filer.
 //
 // EG https://netbox.global.cloud.sap/dcim/devices/?region_id=19&role_id=13&manufacturer_id=11&tenant_id=1&interfaces=False
-func (c Client) getFilers(ctx context.Context, region, tag string) ([]Filer, error) {
+func (c Client) getFilers(ctx context.Context, region string, tags ...string) ([]Filer, error) {
 	netappFilers := make([]Filer, 0)
 	devices := make([]netbox.DeviceWithConfigContext, 0)
 
@@ -50,7 +50,7 @@ func (c Client) getFilers(ctx context.Context, region, tag string) ([]Filer, err
 			Role([]string{"filer"}).
 			Manufacturer([]string{"netapp"}).
 			Region([]string{region}).
-			Tag([]string{tag}).
+			Tag(tags).
 			Interfaces(false).
 			Limit(limit).
 			Offset(offset).


### PR DESCRIPTION
Integrating these changes into the OpenStack harvest poller requires additional time for investigation. To accommodate this, the `SCI Storage Delivery team` is isolating this work within a dedicated feature branch."